### PR TITLE
Added dependancies and restart criteria

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
       timeout: 10s
       retries: 3
       #start_period: 1m
+    depends_on: ["database"]
+    restart: on-failure
     ports:
       - "8080:8080"
 
@@ -43,6 +45,8 @@ services:
       retries: 3
     volumes:
       - './mouse/src:/usr/src/app/src'
+    depends_on: ["webapp"]
+    restart: on-failure
     ports:
       - '3000:3000'
 


### PR DESCRIPTION
mouse depends on webapp, which depends on database
database has reset criteria "always" (default)
webapp and mouse both have reset criteria "on-failure"